### PR TITLE
fix(payment-order): ensure bank account is fetched from payment entry

### DIFF
--- a/india_banking/overrides/payment_entry.py
+++ b/india_banking/overrides/payment_entry.py
@@ -63,6 +63,7 @@ def make_payment_order(source_name, target_doc=None):
 						)
 					),
 				)
+			return bank_account.name
 
 		def _get_reference_data(reference=None):
 			return {


### PR DESCRIPTION
**Issue**

The Payment Order fails to fetch the bank account when pulling a Payment Entry, leaving the Bank Account field empty. This forces users to manually input the account, disrupting the workflow. This PR fixes the issue by ensuring the bank account is automatically populated from the Payment Entry.

**Closes #22**

**Before**

https://github.com/user-attachments/assets/b13695da-5f66-46fd-abe9-13f200b0752a

**after**

[fix.webm](https://github.com/user-attachments/assets/4b391c9a-3cf0-4705-ab45-23ebc4bc38e9)

