### PR TITLE
Feat/naming series

### DIFF
--- a/india_banking/hooks.py
+++ b/india_banking/hooks.py
@@ -40,6 +40,12 @@ doc_events = {
 	"Payment Entry": {
 		"on_cancel": "india_banking.india_banking.doc_events.payment_entry.on_cancel",
 	},
+	"Payment Order": {
+		"autoname": "india_banking.utils.update_series",
+	},
+	"Payment Request": {
+		"autoname": "india_banking.utils.update_series",
+	},
 }
 
 accounting_dimension_doctypes = [

--- a/india_banking/india_banking/doc_events/payment_order.py
+++ b/india_banking/india_banking/doc_events/payment_order.py
@@ -8,6 +8,8 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import get_split_invoi
 from frappe import _, parse_json
 from frappe.utils import flt, nowdate
 
+from india_banking.utils import get_bank_payment_naming_series
+
 
 @frappe.whitelist()
 def cancel_pending_payments(data):
@@ -78,6 +80,13 @@ def make_payment_entries(docname):
 			frappe.throw(_("Summary reference mismatch"))
 
 		pe = frappe.new_doc("Payment Entry")
+		# update bank payment naming series
+		series = get_bank_payment_naming_series(
+			payment_order_doc.company, "Payment Entry"
+		)
+		if series and series != pe.naming_series:
+			pe.naming_series = series
+
 		pe.payment_type = "Pay"
 		pe.payment_entry_type = "Pay"
 		pe.company = payment_order_doc.company

--- a/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.js
+++ b/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.js
@@ -13,6 +13,13 @@ frappe.ui.form.on("India Banking Settings", {
     frm.get_field("allowed_payment_doctypes").$wrapper.click(() => {
       update_allow_doctypes(frm);
     });
+    frm.set_query("doctype_name", "doctype_naming_series", () => {
+      return {
+        filters: {
+          name: ["in", ["Payment Request", "Payment Order", "Payment Entry"]],
+        },
+      };
+    });
   },
 });
 

--- a/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.json
+++ b/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.json
@@ -5,19 +5,24 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "basic_configuration_tab",
   "summarise_payment_based_on",
   "enable_payment_in_the_background",
   "use_payment_order_date_as_payment_entry_date",
   "allow_future_date_payment_order",
   "column_break_wjye",
-  "activate_workflow_on_bank_account",
   "allowed_payment_doctypes",
+  "auto_update_configurations_tab",
   "automatic_update_configuration_section",
   "update_payment_status",
   "status_check",
   "retry_period",
   "column_break_laug",
   "update_posting_date_as_payment_date",
+  "doctype_customization_tab",
+  "activate_workflow_on_bank_account",
+  "doctype_naming_series",
+  "payment_notifications_tab",
   "payment_notifications_section",
   "notify_party",
   "payment_notification"
@@ -67,7 +72,6 @@
    "label": "Auto Update Payment Status"
   },
   {
-   "collapsible": 1,
    "fieldname": "automatic_update_configuration_section",
    "fieldtype": "Section Break",
    "label": "Auto Update Configurations"
@@ -94,7 +98,6 @@
    "options": "Every 20 Minutes\nEvery Hour\nEvery Day at Midnight"
   },
   {
-   "collapsible": 1,
    "fieldname": "payment_notifications_section",
    "fieldtype": "Section Break",
    "label": "Payment Notifications "
@@ -124,12 +127,38 @@
    "fieldname": "allow_future_date_payment_order",
    "fieldtype": "Check",
    "label": "Allow future Date Payment Order"
+  },
+  {
+   "fieldname": "doctype_naming_series",
+   "fieldtype": "Table",
+   "label": "Doctype Naming Series",
+   "options": "Naming Series Map"
+  },
+  {
+   "fieldname": "doctype_customization_tab",
+   "fieldtype": "Tab Break",
+   "label": "DocType Configuration"
+  },
+  {
+   "fieldname": "auto_update_configurations_tab",
+   "fieldtype": "Tab Break",
+   "label": "Auto Update Configurations"
+  },
+  {
+   "fieldname": "payment_notifications_tab",
+   "fieldtype": "Tab Break",
+   "label": "Payment Notifications "
+  },
+  {
+   "fieldname": "basic_configuration_tab",
+   "fieldtype": "Tab Break",
+   "label": "Basic Configuration"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-18 11:23:25.499306",
+ "modified": "2025-07-18 15:52:13.042530",
  "modified_by": "Administrator",
  "module": "India Banking",
  "name": "India Banking Settings",

--- a/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.json
+++ b/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.json
@@ -129,7 +129,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-12 16:13:24.156102",
+ "modified": "2025-07-18 11:23:25.499306",
  "modified_by": "Administrator",
  "module": "India Banking",
  "name": "India Banking Settings",
@@ -144,6 +144,13 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "All",
+   "share": 1
   }
  ],
  "sort_field": "modified",

--- a/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.py
+++ b/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.py
@@ -8,9 +8,23 @@ from frappe.model.document import Document
 class IndiaBankingSettings(Document):
 	def validate(self):
 		self.enable_or_disable_workflow_to_bank_account()
+		self.validate_document_series()
 		self.enable_payment_entry_reposting()
 		if not self.notify_party:
 			self.payment_notification = []
+
+	def validate_document_series(self):
+		if self.doctype_naming_series:
+			for series in self.doctype_naming_series:
+				if series.series:
+					options = frappe.get_meta(series.doctype_name).get_options(
+						"naming_series"
+					)
+					options_list = options.split("\n")
+					if options and series.series not in options_list:
+						frappe.throw(
+							f"You can only select a series that starts with <b>{options_list}</b> at #Row {frappe.bold(series.idx)}"
+						)
 
 	def enable_or_disable_workflow_to_bank_account(self):
 		"""Enable or disable workflow to bank account based on settings."""

--- a/india_banking/india_banking/doctype/naming_series_map/naming_series_map.json
+++ b/india_banking/india_banking/doctype/naming_series_map/naming_series_map.json
@@ -1,0 +1,50 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-07-18 13:07:07.823981",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "company",
+  "doctype_name",
+  "series"
+ ],
+ "fields": [
+  {
+   "fieldname": "doctype_name",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "DocType",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "series",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Series",
+   "reqd": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-07-18 13:42:26.212622",
+ "modified_by": "Administrator",
+ "module": "India Banking",
+ "name": "Naming Series Map",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/india_banking/india_banking/doctype/naming_series_map/naming_series_map.py
+++ b/india_banking/india_banking/doctype/naming_series_map/naming_series_map.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Aerele Technologies Private Limited and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class NamingSeriesMap(Document):
+	pass

--- a/india_banking/public/js/payment_request.js
+++ b/india_banking/public/js/payment_request.js
@@ -53,7 +53,6 @@ function set_bank_account_query(frm) {
 function get_bank_query_conditions(frm) {
   let conditions = {
     company: frm.doc.company,
-    is_default: 1,
     disabled: 0,
   };
   frappe.db

--- a/india_banking/utils.py
+++ b/india_banking/utils.py
@@ -190,3 +190,24 @@ def add_background_job(job_id, job_name, method, **kwargs):
 		_add_queue(job_id, job_name, method, **kwargs)
 
 	return True
+
+
+def get_bank_payment_naming_series(company, doctype):
+	return frappe.get_value(
+		"Naming Series Map", {"company": company, "doctype_name": doctype}, "series"
+	)
+
+
+def update_series(doc, method=None):
+	if doc.doctype == "Payment Request" and doc.payment_request_type != "Outward":
+		return
+
+	if doc.doctype == "Payment Entry" and doc.payment_type != "Pay":
+		return
+
+	series = get_bank_payment_naming_series(company=doc.company, doctype=doc.doctype)
+	if series and series != doc.naming_series:
+		doc.naming_series = series
+		frappe.msgprint(
+			"Naming Series updated based on India Banking settings.", alert=True
+		)


### PR DESCRIPTION
**Issue:**
1. No option to select a payment naming series.
2. No permission to read the India Banking Settings.
3. Only the default bank account can be selected in the Payment Request.

**Fix:**
- Added the option to select a payment naming series based on the selected series in India Banking Settings.
- Granted read permission for India Banking Settings.
- Removed the filter to allow selection of bank accounts other than the default one.

**Backport needed version-15**