### PR TITLE
feat: hold GST payable restriction in bank payment

### DIFF
--- a/india_banking/india_banking/report/bank_gst_payables/bank_gst_payables.js
+++ b/india_banking/india_banking/report/bank_gst_payables/bank_gst_payables.js
@@ -1,0 +1,85 @@
+// Copyright (c) 2025, Aerele Technologies Private Limited and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Bank GST Payables"] = {
+  filters: [
+    {
+      fieldname: "company",
+      label: __("Company"),
+      fieldtype: "Link",
+      options: "Company",
+      reqd: 1,
+      default: frappe.defaults.get_user_default("Company"),
+    },
+    {
+      fieldname: "supplier",
+      label: __("Supplier"),
+      fieldtype: "Link",
+      options: "Supplier",
+    },
+  ],
+  get_datatable_options(options) {
+    options.checkboxColumn = true;
+    return options;
+  },
+  onload: function (report) {
+    frappe.query_report.page.add_inner_button("Goto Payment Request", () => {
+      frappe.set_route("List", "Payment Request");
+    });
+    setTimeout(() => {
+      $('[class="inner-group-button"]').hide();
+      $('[data-label="Create%20Card"]').hide();
+      let status_message = frappe.query_report.$status.html();
+      let newStatus = status_message.replace(
+        "click on Rebuild",
+        "click on Rebuild or Generate New Report"
+      );
+
+      let new_message = `<div style="color: #ff4008;">${newStatus}</>`;
+      frappe.query_report.$status.html(new_message);
+    }, 1000);
+
+    report.page.add_action_item(__("Create Payment Request"), function () {
+      let checked_rows_indexes = report.datatable?.rowmanager.getCheckedRows();
+      let checked_rows = checked_rows_indexes?.map((i) => report.data[i]);
+
+      if (!checked_rows) {
+        return;
+      }
+
+      if (checked_rows && checked_rows.length === 0) {
+        frappe.throw("Select one or more rows");
+      }
+      frappe.call({
+        method:
+          "india_banking.india_banking.report.bank_gst_payables.bank_gst_payables.create_bulk_payment_request",
+        args: {
+          invoices: checked_rows,
+          filters: frappe.query_report.get_filter_values(),
+        },
+        async: false,
+        callback: function (r) {
+          $('[data-original-title="Reload Report"]').click();
+        },
+      });
+    });
+  },
+};
+
+let pay_net_outstanding = function (data) {
+  let invoice = data.split("amt:")[0];
+  let net_outstanding = data.split("amt:")[1];
+  frappe.call({
+    method:
+      "india_banking.india_banking.report.bank_gst_payables.bank_gst_payables.create_single_payment_request",
+    args: {
+      invoice: invoice,
+      net_outstanding: net_outstanding,
+      filters: frappe.query_report.get_filter_values(),
+    },
+    async: false,
+    callback: function (r) {
+      $('[data-original-title="Reload Report"]').click();
+    },
+  });
+};

--- a/india_banking/india_banking/report/bank_gst_payables/bank_gst_payables.json
+++ b/india_banking/india_banking/report/bank_gst_payables/bank_gst_payables.json
@@ -1,0 +1,37 @@
+{
+ "add_total_row": 1,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2025-09-01 16:32:05.467584",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-09-01 23:48:19.798851",
+ "modified_by": "Administrator",
+ "module": "India Banking",
+ "name": "Bank GST Payables",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Purchase Invoice",
+ "report_name": "Bank GST Payables",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Accounts User"
+  },
+  {
+   "role": "Purchase User"
+  },
+  {
+   "role": "Accounts Manager"
+  },
+  {
+   "role": "Auditor"
+  }
+ ],
+ "timeout": 0
+}

--- a/india_banking/india_banking/report/bank_gst_payables/bank_gst_payables.py
+++ b/india_banking/india_banking/report/bank_gst_payables/bank_gst_payables.py
@@ -1,0 +1,227 @@
+# Copyright (c) 2025, Aerele Technologies Private Limited and contributors
+# For license information, please see license.txt
+
+import json
+
+import frappe
+from erpnext.accounts.doctype.payment_request.payment_request import (
+	get_existing_payment_request_amount,
+)
+from frappe import _, bold, get_installed_apps
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Sum
+from frappe.utils import cstr, flt, get_link_to_form
+
+from india_banking.india_banking.report.bulk_create_payment_request.bulk_create_payment_request import (
+	make_payment_request,
+)
+from india_banking.utils import add_background_job
+
+ENQUEUE_LIMIT = 50
+
+
+def execute(filters: dict | None = None):
+	if "india_compliance" not in get_installed_apps():
+		return [], []
+
+	columns = get_columns(filters)
+	data = get_data(filters)
+
+	return columns, data
+
+
+def get_columns(filters=None) -> list[dict]:
+	return [
+		{
+			"label": _("Purchase Invoice"),
+			"fieldname": "purchase_invoice",
+			"fieldtype": "Link",
+			"options": "Purchase Invoice",
+		},
+		{
+			"label": _("Reconciliation Status"),
+			"fieldname": "reconciliation_status",
+			"fieldtype": "Data",
+			"default": "No Found",
+		},
+		{
+			"label": _("Supplier"),
+			"fieldname": "supplier",
+			"fieldtype": "Link",
+			"options": "Supplier",
+		},
+		{
+			"label": _("Hold GST Payables"),
+			"fieldname": "hold_gst_payables",
+			"fieldtype": "check",
+		},
+		{
+			"label": _("Outstanding(Invoice)"),
+			"fieldname": "invoice_outstanding",
+			"fieldtype": "Currency",
+		},
+		{
+			"label": _("Outstanding(Payment Request)"),
+			"fieldname": "request_outstanding",
+			"fieldtype": "Currency",
+		},
+		{
+			"label": _("Net Outstanding"),
+			"fieldname": "net_outstanding",
+			"fieldtype": "Currency",
+		},
+		{
+			"label": _("GST Payable"),
+			"fieldname": "gst_payable",
+			"fieldtype": "Currency",
+		},
+		{
+			"label": _("Pay Net Outstanding"),
+			"fieldname": "action",
+			"fieldtype": "HTML",
+		},
+	]
+
+
+def get_data(filters=None):
+	PII = DocType("Purchase Invoice Item")
+	PI = DocType("Purchase Invoice")
+	SUPP = DocType("Supplier")
+
+	query = (
+		frappe.qb.from_(PII)
+		.join(PI)
+		.on(PI.name == PII.parent)
+		.join(SUPP)
+		.on(SUPP.name == PI.supplier)
+		.select(
+			PI.name.as_("purchase_invoice"),
+			SUPP.name.as_("supplier"),
+			SUPP.supplier_name.as_("supplier_name"),
+			SUPP.hold_gst_payables,
+			PI.outstanding_amount.as_("invoice_outstanding"),
+			PI.reconciliation_status,
+			(Sum(PII.igst_amount) + Sum(PII.cgst_amount) + Sum(PII.sgst_amount)).as_(
+				"gst_payable"
+			),
+		)
+		.where(PI.docstatus == 1)
+		.where(SUPP.hold_gst_payables == 1)
+		.where(PI.company == filters.get("company"))
+		.where(PI.outstanding_amount > 0)
+		.groupby(PII.name)
+	)
+
+	if filters.get("supplier"):
+		query = query.where(PI.supplier == filters.get("supplier"))
+
+	button = """<button class="btn btn-xs btn-default btn-primary" data-fieldtype="Button" data-fieldname="pay_net_outstanding" onclick= pay_net_outstanding('{}')>Create</button>"""
+
+	data = []
+	item_details = query.run(as_dict=True)
+	for details in item_details:
+		if details.gst_payable < 0:
+			continue
+		ref_doc = frappe.get_doc("Purchase Invoice", details.purchase_invoice)
+		request_outstanding = get_existing_payment_request_amount(ref_doc)
+		net_outstanding = details.invoice_outstanding - request_outstanding
+		details.update(
+			{
+				"request_outstanding": request_outstanding,
+				"net_outstanding": net_outstanding,
+				"reconciliation_status": details.reconciliation_status or "N/A",
+				"action": f"{button}".format(
+					details.purchase_invoice + "amt:" + cstr(flt(net_outstanding))
+				),
+			}
+		)
+		if net_outstanding <= 0:
+			continue
+
+		data.append(details)
+
+	return data
+
+
+@frappe.whitelist()
+def create_single_payment_request(invoice, net_outstanding, filters=None):
+	net_total = flt(net_outstanding)
+	invoice = frappe.get_doc("Purchase Invoice", invoice)
+	if isinstance(filters, str):
+		filters = json.loads(filters)
+	payment_details = {
+		"payment_request_type": "Outward",
+		"company": filters.get("company"),
+		"mode_of_payment": "Wire Transfer",
+		"payment_type": frappe.db.exists(
+			"Payment Type", {"company": filters.get("company"), "is_default": 1}
+		),
+		"party_type": "Supplier",
+		"party": invoice.supplier,
+		"reference_doctype": "Purchase Invoice",
+		"reference_name": invoice.name,
+		"net_total": net_total,
+	}
+	frappe.flags.ignore_hold_gst_payables = True
+	try:
+		pr = make_payment_request(**payment_details)
+		frappe.flags.ignore_hold_gst_payables = False
+		link = get_link_to_form("Payment Request", pr.name)
+		frappe.msgprint("payment request {}".format(bold(link)))
+	except Exception:
+		pass
+
+
+@frappe.whitelist()
+def create_bulk_payment_request(invoices, filters=None):
+	if isinstance(invoices, str):
+		invoices = json.loads(invoices)
+	if isinstance(filters, str):
+		filters = json.loads(filters)
+
+	if not invoices:
+		return []
+
+	count = 0
+	zero_outstanding = 0
+	for invoice in invoices:
+		invoice = frappe._dict(invoice)
+		net_total = flt(invoice.gst_payable)
+		payment_details = {
+			"payment_request_type": "Outward",
+			"company": filters.get("company"),
+			"mode_of_payment": "Wire Transfer",
+			"payment_type": frappe.db.exists(
+				"Payment Type", {"company": filters.get("company"), "is_default": 1}
+			),
+			"party_type": "Supplier",
+			"party": invoice.supplier,
+			"reference_doctype": "Purchase Invoice",
+			"reference_name": invoice.purchase_invoice,
+			"net_total": net_total,
+		}
+
+		if not net_total:
+			zero_outstanding += 1
+		else:
+			if len(invoices) > ENQUEUE_LIMIT:
+				job_id = invoice.voucher_no + cstr(invoice.payment_term)
+				job_name = invoice.voucher_no + "-" + cstr(invoice.payment_term)
+				method = make_payment_request
+				add_background_job(job_id, job_name, method, **payment_details)
+			else:
+				frappe.flags.ignore_hold_gst_payables = True
+				try:
+					make_payment_request(**payment_details)
+				except Exception:
+					pass
+				frappe.flags.ignore_hold_gst_payables = False
+			count += 1
+	if count:
+		msg = "{} Row Updated".format(count)
+		if len(invoices) > ENQUEUE_LIMIT:
+			msg = "{} Row added in background job".format(count)
+		frappe.msgprint(msg)
+
+	if not count and zero_outstanding:
+		frappe.msgprint("No more outstanding to Pay")

--- a/india_banking/install.py
+++ b/india_banking/install.py
@@ -35,6 +35,7 @@ def make_custom_fields():
 	create_payment_order_custom_fields()
 	create_payment_entry_custom_fields()
 	create_journal_entry_custom_fields()
+	create_supplier_custom_fields()
 
 
 def update_allowed_payment_doctypes():
@@ -121,7 +122,14 @@ def create_supplier_custom_fields():
 				"fieldtype": "Data",
 				"owner": "Administrator",
 				"insert_after": "tax_id",
-			}
+			},
+			{
+				"label": "Hold GST Payables",
+				"fieldname": "hold_gst_payables",
+				"fieldtype": "Check",
+				"owner": "Administrator",
+				"insert_after": "is_reverse_charge_applicable",
+			},
 		]
 	}
 
@@ -165,7 +173,7 @@ def create_payment_request_custom_fields():
 			"label": "Apply Tax Withholding Amount",
 			"fieldname": "apply_tax_withholding_amount",
 			"fieldtype": "Check",
-			"depends_on": "eval:doc.party_type == 'Supplier' && doc.reference_doctype != 'Purchase Invoice' && doc.payment_request_type == 'Outward'",
+			"depends_on": "eval:doc.is_adhoc",
 			"insert_after": "currency",
 		},
 		{
@@ -174,7 +182,7 @@ def create_payment_request_custom_fields():
 			"fieldtype": "Link",
 			"options": "Tax Withholding Category",
 			"depends_on": "eval:doc.apply_tax_withholding_amount",
-			"insert_after": "apply_tax_withholding_amount",
+			"insert_after": "payment_term",
 		},
 		{
 			"label": "Payment Term",
@@ -196,6 +204,14 @@ def create_payment_request_custom_fields():
 			"fieldtype": "Small Text",
 			"depends_on": "eval:doc.payment_request_type == 'Outward'",
 			"insert_after": "remark_section",
+		},
+		{
+			"label": "Hold GST Payables",
+			"fieldname": "hold_gst_payables",
+			"fieldtype": "Check",
+			"owner": "Administrator",
+			"insert_after": "tax_withholding_category",
+			"hidden": 1,
 		},
 	]
 

--- a/india_banking/overrides/payment_request.py
+++ b/india_banking/overrides/payment_request.py
@@ -4,13 +4,20 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 )
 from erpnext.accounts.doctype.payment_request.payment_request import (
 	PaymentRequest,
+	get_existing_payment_request_amount,
 )
 from erpnext.accounts.doctype.tax_withholding_category.tax_withholding_category import (
 	get_party_tax_withholding_details,
 )
 from erpnext.accounts.party import get_party_bank_account
-from frappe import _
-from frappe.utils import get_url_to_form, getdate
+from frappe import _, bold
+from frappe.utils import (
+	flt,
+	get_link_to_form,
+	get_link_to_report,
+	get_url_to_form,
+	getdate,
+)
 
 
 class BankPaymentRequest(PaymentRequest):
@@ -41,8 +48,101 @@ class BankPaymentRequest(PaymentRequest):
 		if self.remarks:
 			self.remarks = self.remarks[:48]
 
-	def validate_payment_request_amount(self):
-		super().validate_payment_request_amount()
+	def validate_and_update_gst_payables(self, update=False):
+		if self.is_adhoc or "india_compliance" not in frappe.get_installed_apps():
+			return
+
+		if frappe.flags.ignore_hold_gst_payables:
+			return
+
+		if (
+			self.party_type == "Supplier"
+			and not self.hold_gst_payables
+			and self.docstatus == 0
+		):
+			self.hold_gst_payables = frappe.db.get_value(
+				self.party_type, self.party, "hold_gst_payables"
+			)
+
+		ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
+		existing_payment_request_amount = get_existing_payment_request_amount(ref_doc)
+		gst_payable_amount = self.get_gst_payable_amount()
+
+		if update:
+			applicable_payment_amount = self.grand_total - gst_payable_amount
+			if applicable_payment_amount <= 0:
+				applicable_payment_amount = 0
+				link = get_link_to_report("Bank GST Payables")
+				msg = "We observed the following:"
+				msg += "<ul><li>Total Requested Amount: {}</li>".format(
+					bold(existing_payment_request_amount)
+				)
+				msg += "<li>Outstanding Amount: {}</li>".format(
+					bold(ref_doc.outstanding_amount)
+				)
+				msg += "<li>Net Payable(GST Exclusive): {}</li>".format(
+					bold(applicable_payment_amount)
+				)
+				msg += "<li>GST Payables: {}</li></ul>".format(
+					bold(flt(gst_payable_amount))
+				)
+				msg += "Please use the {} report to process GST payables.".format(
+					bold(link)
+				)
+				frappe.throw(title="Hold Supplier GST Payable", msg=msg)
+			self.net_total = applicable_payment_amount
+		else:
+			if self.hold_gst_payables:
+				applicable_payment_amount = (
+					ref_doc.outstanding_amount
+					- existing_payment_request_amount
+					- gst_payable_amount
+				)
+				if gst_payable_amount and applicable_payment_amount < 0:
+					applicable_payment_amount = 0
+					link = get_link_to_report("Bank GST Payables")
+					frappe.throw(
+						title="Hold Supplier GST Payable",
+						msg="Supplier {} is marked for Hold GST. The eligible payment amount is < {}. use {} report to make GST payable against".format(
+							bold(link), bold(applicable_payment_amount), link
+						),
+					)
+
+				if self.net_total > applicable_payment_amount:
+					link = get_link_to_form("Supplier", self.party)
+					frappe.throw(
+						title="Hold Supplier GST Payable",
+						msg="Supplier {} is marked for Hold GST. The eligible payment amount is < {}".format(
+							bold(link), bold(applicable_payment_amount)
+						),
+					)
+
+	def get_gst_payable_amount(self):
+		total_gst_payable_amount = 0
+		if (
+			self.reference_doctype
+			and self.reference_doctype == "Purchase Invoice"
+			and self.reference_name
+		):
+			gst_payable_totals = frappe.db.get_all(
+				"Purchase Invoice Item",
+				filters={"parent": self.reference_name},
+				fields=[
+					"SUM(igst_amount) as total_igst",
+					"SUM(cgst_amount) as total_cgst",
+					"SUM(sgst_amount) as total_sgst",
+				],
+			)
+
+			total_igst, total_cgst, total_sgst = 0, 0, 0
+			if gst_payable_totals:
+				total_igst = gst_payable_totals[0].total_igst
+				total_cgst = gst_payable_totals[0].total_cgst
+				total_sgst = gst_payable_totals[0].total_sgst
+
+			total_gst_payable_amount = total_igst + total_cgst + total_sgst
+
+		return total_gst_payable_amount
 
 	def set_default_value(self):
 		if not self.transaction_date:
@@ -69,6 +169,13 @@ class BankPaymentRequest(PaymentRequest):
 
 		if self.bank_account:
 			self.mode_of_payment = "Wire Transfer"
+
+	def before_insert(self):
+		self.validate_and_update_gst_payables(update=True)
+
+	def before_submit(self):
+		super().before_submit()
+		self.validate_and_update_gst_payables()
 
 	def on_submit(self):
 		if not self.grand_total or not self.net_total:


### PR DESCRIPTION
This PR introduces a Hold GST Payable restriction in the Payment Request workflow.  

- Adds a supplier-level setting (`hold_gst_payables`).  
- When enabled, payments cannot be made below the GST payable amount.  
- Provides a user-facing validation message with payable breakdown.  
- Ensures compliance by redirecting users to the Bank GST Payables report for GST settlement.

**backport needed v15**