### PR TITLE
fix: status customisation

### DIFF
--- a/india_banking/india_banking/doctype/bank_connector/bank_connector.py
+++ b/india_banking/india_banking/doctype/bank_connector/bank_connector.py
@@ -11,7 +11,6 @@ import requests as request
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_days, cint, cstr, flt, getdate
-from frappe.utils.background_jobs import is_job_enqueued
 
 from india_banking.india_banking.doctype.india_banking_request_log.india_banking_request_log import (
 	create_api_log,
@@ -84,7 +83,12 @@ class BankConnector(Document):
 			frappe.throw(_("Invalid Response: Check API Log"))
 
 	def make_post_request(
-		self, payment_order, otp=None, action=None, check_processed_payments=False
+		self,
+		payment_order,
+		otp=None,
+		action=None,
+		statuses=None,
+		check_processed_payments=False,
 	):
 		self.check_user_permission()
 
@@ -123,20 +127,18 @@ class BankConnector(Document):
 			for summary in payment_order.summary:
 				if self.action == "initiate_payment":
 					last_call = self.check_payment_delay(last_call)
-					if (
-						summary.payment_initiated
-						or summary.payment_status != "Pending"
-					):
+					if summary.payment_initiated or summary.payment_status != "Pending":
 						# Ignoring Already initiated Payment
 						continue
 				elif self.action == "get_payment_status":
-					statuses = ["Pending", "Initiated"]
+					if not statuses:
+						statuses = ["Pending", "Initiated"]
 					if check_processed_payments:
 						retry_period = cint(
 							frappe.get_single("India Banking Settings").retry_period
 						)
 						if summary.payment_date >= add_days(getdate(), -(retry_period)):
-							statuses.append("Processed")
+							statuses = ["Processed"]
 					if summary.payment_status not in statuses:
 						continue
 				self.make_single_request(payment_order, summary)
@@ -201,6 +203,23 @@ class BankConnector(Document):
 								"message": details.get("message", ""),
 							},
 						)
+						summary = frappe.get_doc("Payment Order Summary", _name)
+						if summary.payment_entry:
+							self.process_bank_payment_requests(payment_order, summary)
+
+							payment_entry_doc = frappe.get_doc(
+								"Payment Entry", summary.payment_entry
+							)
+							if payment_entry_doc.docstatus == 1:
+								payment_entry_doc.cancel()
+
+						if summary.journal_entry_account:
+							frappe.db.set_value(
+								"Journal Entry Account",
+								summary.journal_entry_account,
+								"payment_status",
+								"Failed",
+							)
 						self.failed_count += 1
 
 					elif details.get("payment_status", "") == "Request Failure":
@@ -741,14 +760,17 @@ def make_payment(payment_order, otp=None):
 
 
 @frappe.whitelist()
-def get_payment_status(payment_order, check_processed_payments=False):
+def get_payment_status(payment_order, statuses=None, check_processed_payments=False):
 	payment_order = frappe.get_doc("Payment Order", payment_order)
 	bank_connector = get_bank_connector(
 		payment_order.company_bank_account, payment_order.company
 	)
+	if not statuses:
+		statuses = []
 	return bank_connector.make_post_request(
 		payment_order,
 		action="get_payment_status",
+		statuses=statuses,
 		check_processed_payments=check_processed_payments,
 	)
 

--- a/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.json
+++ b/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.json
@@ -9,6 +9,8 @@
   "summarise_payment_based_on",
   "use_payment_order_date_as_payment_entry_date",
   "allow_future_date_payment_order",
+  "enable_status_update_for_failed_payments",
+  "enable_status_update_for_processed_payments",
   "column_break_wjye",
   "allowed_payment_doctypes",
   "auto_update_configurations_tab",
@@ -188,19 +190,31 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "10",
    "depends_on": "auto_post_payments",
    "description": "Max payments per batch in background processing.",
    "fieldname": "batch_size",
    "fieldtype": "Int",
-   "label": "Batch Size",
-   "default": "10"
+   "label": "Batch Size"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_status_update_for_failed_payments",
+   "fieldtype": "Check",
+   "label": "Enable Status Update for Failed Payments"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_status_update_for_processed_payments",
+   "fieldtype": "Check",
+   "label": "Enable Status Update for Processed Payments"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-06 07:32:57.302261",
- "modified_by": "bhavan@aerele.in",
+ "modified": "2025-10-14 00:52:04.633389",
+ "modified_by": "Administrator",
  "module": "India Banking",
  "name": "India Banking Settings",
  "owner": "Administrator",

--- a/india_banking/public/js/payment_order.js
+++ b/india_banking/public/js/payment_order.js
@@ -2,16 +2,11 @@ frappe.ui.form.on("Payment Order", {
 	onload(frm) {
 		// Set summary based on party or voucher
 		if (frm.doc.docstatus == 0) {
-			frappe.db
-				.get_single_value(
-					"India Banking Settings",
-					"summarise_payment_based_on"
-				)
-				.then((res) => {
-					if (!res.exc) {
-						frm.set_value("summarise_payment_based_on", res);
-					}
-				});
+			frappe.db.get_single_value("India Banking Settings", "summarise_payment_based_on").then((res) => {
+				if (!res.exc) {
+					frm.set_value("summarise_payment_based_on", res);
+				}
+			});
 		}
 
 		// Clear the references table for new documents
@@ -69,11 +64,7 @@ frappe.ui.form.on("Payment Order", {
 		const has_pending_payment = frm.doc.summary?.filter(
 			(item) => item.payment_status == "Pending"
 		).length;
-		if (
-			has_pending_payment &&
-			has_pending_payment < frm.doc.summary.length &&
-			frm.doc.docstatus == 1
-		){
+		if (has_pending_payment && has_pending_payment < frm.doc.summary.length && frm.doc.docstatus == 1) {
 			frm.add_custom_button(__("Cancel Pending Payments"), function () {
 				show_update_status_dialog(frm);
 			});
@@ -151,7 +142,7 @@ frappe.ui.form.on("Payment Order", {
 				bank: frm.doc.bank,
 				name: ["not in", existing_payment_requests],
 				company: frm.doc.company,
-				transaction_date: ["<=", frappe.datetime.get_today()]
+				transaction_date: ["<=", frappe.datetime.get_today()],
 			},
 		});
 	},
@@ -216,11 +207,7 @@ frappe.ui.form.on("Payment Order", {
 			get_query: function () {
 				// Extract unique reference names from the references table
 				const existing_journal_entries = [
-					...new Set(
-						(frm.doc.references || []).map(
-							(reference) => reference.reference_name
-						)
-					),
+					...new Set((frm.doc.references || []).map((reference) => reference.reference_name)),
 				];
 				return {
 					query: "india_banking.overrides.journal_entry.get_bank_entry",
@@ -233,16 +220,11 @@ frappe.ui.form.on("Payment Order", {
 		});
 	},
 
-	set_payment_and_status_buttons(frm) {
+	async set_payment_and_status_buttons(frm) {
 		// Check if the document is in a pending state and user has write permissions
-		if (
-			frm.doc.docstatus === 1 &&
-			frm.has_perm("write")
-		) {
+		if (frm.doc.docstatus === 1 && frm.has_perm("write")) {
 			// Check if any summary item has a payment status of "Pending"
-			const has_pending_payments = frm.doc.summary.some(
-				(item) => item.payment_status === "Pending"
-			);
+			const has_pending_payments = frm.doc.summary.some((item) => item.payment_status === "Pending");
 
 			if (frappe.user_roles.includes("Payment Manager") && has_pending_payments) {
 				// Add a custom button to initiate payment
@@ -252,29 +234,39 @@ frappe.ui.form.on("Payment Order", {
 			}
 		}
 
-		if (
-			frm.doc.docstatus === 1 &&
-			frm.has_perm("write")
-		) {
+		if (frm.doc.docstatus === 1 && frm.has_perm("write")) {
 			const has_initiated_or_non_pending = frm.doc.summary.some(
-				(item) =>
-					item.payment_status === "Initiated" ||
-					item.payment_status !== "Pending"
+				(item) => item.payment_status === "Initiated" || item.payment_status !== "Pending"
 			);
 
 			if (has_initiated_or_non_pending) {
 				frm.dashboard.add_comment(
-					"Payment is already initiated. Check the status using the 'Get Status' button before trying again.",
-					permanent = false
+					"Payment is already initiated. Check the status using the 'Get Status' button before trying again."
 				);
+				// Update statuses dynamically based on configuration
+				let statuses = ["Pending", "Initiated"];
+				const for_failed_payment = await frappe.db.get_single_value(
+					"India Banking Settings",
+					"enable_status_update_for_failed_payments"
+				);
+				const for_processed_payment = await frappe.db.get_single_value(
+					"India Banking Settings",
+					"enable_status_update_for_processed_payments"
+				);
+				if (for_failed_payment) {
+					statuses.push("Failed");
+				}
+				if (for_processed_payment) {
+					statuses.push("Processed");
+				}
 				frm.add_custom_button(__("Get Status"), () => {
 					frappe.call({
-						method:
-							"india_banking.india_banking.doctype.bank_connector.bank_connector.get_payment_status",
+						method: "india_banking.india_banking.doctype.bank_connector.bank_connector.get_payment_status",
 						freeze: true,
 						freeze_message: __("Fetching payment status..."),
 						args: {
 							payment_order: frm.doc.name,
+							statuses: statuses,
 						},
 						callback: function () {
 							frm.reload_doc();
@@ -287,8 +279,7 @@ frappe.ui.form.on("Payment Order", {
 
 	make_payment: function (frm) {
 		frappe.call({
-			method:
-				"india_banking.india_banking.doctype.bank_connector.bank_connector.make_payment",
+			method: "india_banking.india_banking.doctype.bank_connector.bank_connector.make_payment",
 			freeze: true,
 			freeze_message: __("Initiating Payment..."),
 			args: {
@@ -328,8 +319,7 @@ frappe.ui.form.on("Payment Order", {
 				}
 
 				frappe.call({
-					method:
-						"india_banking.india_banking.doctype.bank_connector.bank_connector.make_payment",
+					method: "india_banking.india_banking.doctype.bank_connector.bank_connector.make_payment",
 					freeze: true,
 					freeze_message: __("Verifying OTP and processing payment..."),
 					args: {
@@ -493,8 +483,7 @@ const show_update_status_dialog = function (frm) {
 		],
 		primary_action: () => {
 			frm.call({
-				method:
-					"india_banking.india_banking.doc_events.payment_order.cancel_pending_payments",
+				method: "india_banking.india_banking.doc_events.payment_order.cancel_pending_payments",
 				args: {
 					data: dialog.get_values()["summary"],
 				},


### PR DESCRIPTION
This PR introduces an option to update the status of processed and failed payments in Payment Order.

<img width="1917" height="516" alt="image" src="https://github.com/user-attachments/assets/fb4b0347-1062-4c9e-9f03-06ff21f3306e" />

Once the option is enabled, the system will check the status of failed and processed payments.
