### PR TITLE
feat: add h2h support

### DIFF
--- a/india_banking/default.py
+++ b/india_banking/default.py
@@ -60,11 +60,11 @@ STD_BANK_LIST = [
 	"Union Bank of India",
 	"Bank of Baroda",
 	"IDFC Bank",
-	"City Bank",
+	"CITI Bank",
 ]
 
 H2H_ENABLED_BANKS = [
-	"City Bank",
+	"CITI Bank",
 ]
 
 DEFAULT_ROLES = ["Payment Manager"]

--- a/india_banking/default.py
+++ b/india_banking/default.py
@@ -60,6 +60,7 @@ STD_BANK_LIST = [
 	"Union Bank of India",
 	"Bank of Baroda",
 	"IDFC Bank",
+	"City Bank",
 ]
 
 DEFAULT_ROLES = ["Payment Manager"]

--- a/india_banking/default.py
+++ b/india_banking/default.py
@@ -63,6 +63,10 @@ STD_BANK_LIST = [
 	"City Bank",
 ]
 
+H2H_ENABLED_BANKS = [
+	"City Bank",
+]
+
 DEFAULT_ROLES = ["Payment Manager"]
 
 DEFAULT_WORKFLOW_STATE = [

--- a/india_banking/india_banking/doctype/bank_connector/bank_connector.js
+++ b/india_banking/india_banking/doctype/bank_connector/bank_connector.js
@@ -18,7 +18,7 @@ frappe.ui.form.on("Bank Connector", {
 		frm.events.toggle_fields(frm);
 	},
 	toggle_fields(frm) {
-		if (frm.doc.bank === "City Bank") {
+		if (frm.doc.bank === "CITI Bank") {
 			if (frm.is_new()) {
 				frm.set_value("integration_mode", "H2H");
 			}

--- a/india_banking/india_banking/doctype/bank_connector/bank_connector.js
+++ b/india_banking/india_banking/doctype/bank_connector/bank_connector.js
@@ -2,16 +2,32 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Bank Connector", {
-  refresh(frm) {
-    frm.set_query("bank_account", function (doc) {
-      return {
-        filters: {
-          disabled: 0,
-          is_default: 1,
-          is_company_account: 1,
-          company: doc.company,
-        },
-      };
-    });
-  },
+	refresh(frm) {
+		frm.set_query("bank_account", function (doc) {
+			return {
+				filters: {
+					disabled: 0,
+					is_company_account: 1,
+					company: doc.company,
+				},
+			};
+		});
+		frm.events.toggle_fields(frm);
+	},
+	bank_account(frm) {
+		frm.events.toggle_fields(frm);
+	},
+	toggle_fields(frm) {
+		if (frm.doc.bank === "City Bank") {
+			if (frm.is_new()) {
+				frm.set_value("integration_mode", "H2H");
+			}
+			frm.set_df_property("integration_mode", "hidden", 0);
+		} else {
+			if (frm.is_new()) {
+				frm.set_value("integration_mode", "API");
+			}
+			frm.set_df_property("integration_mode", "hidden", 1);
+		}
+	},
 });

--- a/india_banking/india_banking/doctype/bank_connector/bank_connector.json
+++ b/india_banking/india_banking/doctype/bank_connector/bank_connector.json
@@ -13,6 +13,7 @@
   "bank",
   "url",
   "column_break_mdgf",
+  "integration_mode",
   "api_key",
   "api_secret",
   "bulk_transaction"
@@ -76,11 +77,19 @@
    "fieldname": "bulk_transaction",
    "fieldtype": "Check",
    "label": "Bulk Transaction"
+  },
+  {
+   "default": "API",
+   "fieldname": "integration_mode",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Integration Mode",
+   "options": "API\nH2H"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-12-30 11:20:01.236058",
+ "modified": "2026-01-21 11:18:25.159516",
  "modified_by": "Administrator",
  "module": "India Banking",
  "name": "Bank Connector",

--- a/india_banking/india_banking/doctype/bank_connector/bank_connector.py
+++ b/india_banking/india_banking/doctype/bank_connector/bank_connector.py
@@ -68,6 +68,7 @@ class BankConnector(Document):
 						f"H2H Integration is not supported for {self.bank}. Please select API Integration mode."
 					)
 				)
+			self.bulk_transaction = 1
 
 	def get_payload(self, payment_order, action=None, otp=None):
 		bank_account = frappe.get_doc(
@@ -85,6 +86,7 @@ class BankConnector(Document):
 		)
 		payment_payload.method = self.get("action", "") or action
 		payment_payload.bulk_transaction = self.bulk_transaction
+		payment_payload.integration_mode = self.integration_mode
 		payment_payload.doc.otp = otp
 
 		return payment_payload
@@ -611,6 +613,7 @@ class BankConnector(Document):
 		payload.doc = doc
 		payload.method = "get_bank_balance"
 		payload.bulk_transaction = self.bulk_transaction
+		payload.integration_mode = self.integration_mode
 
 		response = request.post(
 			self.connector_url, headers=self.headers, data=json.dumps(payload)
@@ -703,6 +706,7 @@ class BankConnector(Document):
 		payload.doc = doc
 		payload.method = "get_bank_statement"
 		payload.bulk_transaction = self.bulk_transaction
+		payload.integration_mode = self.integration_mode
 
 		response = request.post(
 			self.connector_url, headers=self.headers, data=json.dumps(payload)

--- a/india_banking/india_banking/doctype/bank_connector/bank_connector.py
+++ b/india_banking/india_banking/doctype/bank_connector/bank_connector.py
@@ -115,7 +115,7 @@ class BankConnector(Document):
 		if otp:
 			self.verify_otp(payment_order, otp)
 
-		if self.bulk_transaction:
+		if self.bulk_transaction or self.integration_mode == "H2H":
 			url = self.connector_url
 			headers = self.headers
 

--- a/india_banking/india_banking/doctype/bank_connector/bank_connector.py
+++ b/india_banking/india_banking/doctype/bank_connector/bank_connector.py
@@ -12,6 +12,7 @@ from frappe.model.document import Document
 from frappe.utils import add_days, cint, cstr, flt, getdate
 from frappe.utils.background_jobs import is_job_enqueued
 
+from india_banking.default import H2H_ENABLED_BANKS
 from india_banking.india_banking.doctype.india_banking_request_log.india_banking_request_log import (
 	create_api_log,
 )
@@ -55,6 +56,18 @@ class BankConnector(Document):
 
 	def verify_otp(self, payment_order, otp):
 		pass
+
+	def validate(self):
+		self.validate_integration_mode()
+
+	def validate_integration_mode(self):
+		if self.integration_mode == "H2H":
+			if self.bank not in H2H_ENABLED_BANKS:
+				frappe.throw(
+					_(
+						f"H2H Integration is not supported for {self.bank}. Please select API Integration mode."
+					)
+				)
 
 	def get_payload(self, payment_order, action=None, otp=None):
 		bank_account = frappe.get_doc(

--- a/india_banking/patches.txt
+++ b/india_banking/patches.txt
@@ -4,5 +4,5 @@ india_banking.patches.v1_0.update_custom_fields
 [post_model_sync]
 india_banking.patches.v15_0.remove_payroll_entry_custom_fields #31032025
 
-india_banking.patches.v15_0.update_default_bank #3012251
+india_banking.patches.v15_0.update_default_bank #210126
 india_banking.patches.v15_0.update_custom_field #3012252

--- a/india_banking/public/js/payment_request.js
+++ b/india_banking/public/js/payment_request.js
@@ -1,72 +1,67 @@
 frappe.ui.form.on("Payment Request", {
-  refresh(frm) {
-    if (
-      frm.doc.payment_request_type == "Outward" &&
-      ["Initiated", "Partially Paid"].includes(frm.doc.status)
-    ) {
-      frm.remove_custom_button(__("Create Payment Entry"));
-      cur_frm
-        .add_custom_button("Goto Payment Order", function () {
-          frappe.set_route("List", "Payment Order");
-        })
-        .addClass("btn-primary");
-    }
+	refresh(frm) {
+		if (
+			frm.doc.payment_request_type == "Outward" &&
+			["Initiated", "Partially Paid"].includes(frm.doc.status)
+		) {
+			frm.remove_custom_button(__("Create Payment Entry"));
+			cur_frm.add_custom_button("Goto Payment Order", function () {
+				frappe.set_route("List", "Payment Order");
+			});
+		}
 
-    set_payment_type_query(frm);
-    set_bank_account_query(frm);
-  },
-  company(frm) {
-    set_payment_type_query(frm);
-  },
-  mode_of_payment(frm) {
-    set_bank_account_query(frm);
-  },
-  party_type(frm) {
-    set_bank_account_query(frm);
-  },
-  party(frm) {
-    set_bank_account_query(frm);
-  },
+		set_payment_type_query(frm);
+		set_bank_account_query(frm);
+	},
+	company(frm) {
+		set_payment_type_query(frm);
+	},
+	mode_of_payment(frm) {
+		set_bank_account_query(frm);
+	},
+	party_type(frm) {
+		set_bank_account_query(frm);
+	},
+	party(frm) {
+		set_bank_account_query(frm);
+	},
 });
 
 function set_payment_type_query(frm) {
-  frm.set_query("payment_type", function () {
-    return {
-      filters: {
-        company: frm.doc.company,
-      },
-    };
-  });
+	frm.set_query("payment_type", function () {
+		return {
+			filters: {
+				company: frm.doc.company,
+			},
+		};
+	});
 }
 
 function set_bank_account_query(frm) {
-  let conditions = get_bank_query_conditions(frm);
-  frm.set_query("bank_account", function () {
-    return {
-      filters: conditions,
-    };
-  });
+	let conditions = get_bank_query_conditions(frm);
+	frm.set_query("bank_account", function () {
+		return {
+			filters: conditions,
+		};
+	});
 }
 
 function get_bank_query_conditions(frm) {
-  let conditions = {
-    disabled: 0,
-  };
-  frappe.db
-    .get_single_value(
-      "India Banking Settings",
-      "activate_workflow_on_bank_account"
-    )
-    .then((r) => {
-      if (r) {
-        conditions["workflow_state"] = "Approved";
-      }
-    });
-  if (frm.doc.party_type) {
-    conditions["party_type"] = frm.doc.party_type;
-  }
-  if (frm.doc.party) {
-    conditions["party"] = frm.doc.party;
-  }
-  return conditions;
+	let conditions = {
+		disabled: 0,
+	};
+	frappe.db
+		.get_single_value("India Banking Settings", "activate_workflow_on_bank_account")
+		.then((r) => {
+			if (r) {
+				conditions["workflow_state"] = "Approved";
+			}
+		});
+	if (frm.doc.party_type) {
+		conditions["party_type"] = frm.doc.party_type;
+	}
+	if (frm.doc.party) {
+		conditions["party"] = frm.doc.party;
+	}
+	return conditions;
 }


### PR DESCRIPTION
This PR introduces support for Host-to-Host (H2H) integration by extending the existing API-based flow with an integration mode selection. The change allows the system to dynamically choose the appropriate integration path without impacting existing API functionality.

## Key Changes

- Added integration_mode to distinguish between API and H2H integrations
- Included integration_mode in request payloads
- Added validation to ensure a valid integration mode is provided
- Kept backward compatibility for existing API-based integrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CITI Bank support with automatic H2H (high-to-high) integration mode.
  * Introduced Integration Mode field for bank connectors with intelligent bank-specific defaults.

* **Enhancements**
  * Added validation to ensure H2H operations are only used with compatible banks.
  * Improved payment request flow with integration mode awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->