### PR TITLE
chore(deps): allow frappe versions 14.x and 15.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,6 @@ build-backend = "flit_core.buildapi"
 quote-style = "double"
 indent-style = "tab"
 docstring-code-format = true
+
+[tool.bench.frappe-dependencies]
+frappe = ">=14,<16"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized project configuration settings for code formatting and documentation standards.
  * Updated dependency constraints for frappe, specifying version compatibility between 14 and 16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->