### PR TITLE
fix: unlink payment entry

### DIFF
--- a/india_banking/india_banking/doc_events/payment_order.py
+++ b/india_banking/india_banking/doc_events/payment_order.py
@@ -12,13 +12,18 @@ from india_banking.utils import get_bank_payment_naming_series
 
 
 @frappe.whitelist()
-def cancel_pending_payments(data):
+def cancel_pending_payments(payment_order_type, data):
 	if isinstance(data, str) or isinstance(data, dict):
 		data = parse_json(data)
 
 	success_count = 0
 	for d in data:
 		d = parse_json(d)
+
+		if payment_order_type != "Payment Request":
+			success_count += unlink_payment_reference(summary=d)
+			continue
+
 		if d.row_name:
 			if d.status == "Failed":
 				frappe.db.set_value(
@@ -37,6 +42,49 @@ def cancel_pending_payments(data):
 				success_count += 1
 	if success_count:
 		frappe.msgprint(_(f"{success_count} payment(s) updated"))
+
+
+def unlink_payment_reference(summary):
+	_comments = []
+	try:
+		po, po_references = frappe.db.get_value(
+			"Payment Order Summary", summary.row_name, ["parent", "summary_references"]
+		)
+		summary_references = ast.literal_eval(po_references)
+		for reference in summary_references:
+			ref_type, ref_name = frappe.db.get_value(
+				"Payment Order Reference",
+				reference,
+				["reference_doctype", "reference_name"],
+			)
+			frappe.db.set_value(
+				"Payment Order Reference",
+				reference,
+				{
+					"reference_name": "",
+					"payment_entry": "",
+				},
+			)
+			_comments.append(
+				"{} - {} has been unlinked from the reference {}".format(
+					ref_type, ref_name, reference
+				)
+			)
+		else:
+			frappe.db.set_value(
+				"Payment Order Summary",
+				summary.row_name,
+				{"payment_status": "Failed", "payment_initiated": 1},
+			)
+		frappe.get_doc("Payment Order", po).add_comment(
+			"Comment", "<br>".join(_comments)
+		)
+		return 1
+	except Exception:
+		frappe.log_error(
+			"Failed to unlink payment", frappe.get_traceback(with_context=1)
+		)
+		return 0
 
 
 def process_payment_requests(payment_order_summary):
@@ -249,7 +297,12 @@ def group_by_invoices(self):
 	grouped_references = {}
 	if self.references:
 		for ref in self.references:
-			key = (ref.reference_name, ref.reference_doctype, ref.payment_term, ref.payment_request)
+			key = (
+				ref.reference_name,
+				ref.reference_doctype,
+				ref.payment_term,
+				ref.payment_request,
+			)
 			if key not in grouped_references:
 				grouped_references[key] = ref
 			else:

--- a/india_banking/overrides/payment_entry.py
+++ b/india_banking/overrides/payment_entry.py
@@ -82,9 +82,8 @@ def make_payment_order(source_name, target_doc=None):
 				"mode_of_payment": source.mode_of_payment
 				if reference
 				else "Wire Transfer",
-				"bank_account": _get_default_bank_account(
-					source.party_type, source.party
-				),
+				"bank_account": source.party_bank_account
+				or _get_default_bank_account(source.party_type, source.party),
 				"account": account if reference else source.paid_to,
 				"cost_center": source.cost_center,
 				"project": source.project,

--- a/india_banking/public/js/payment_order.js
+++ b/india_banking/public/js/payment_order.js
@@ -188,7 +188,7 @@ frappe.ui.form.on("Payment Order", {
 					label: "Company",
 					fieldname: "company",
 					options: "Company",
-					default: frappe.defaults.get_user_default("company"),
+					default: frm.doc.company || frappe.defaults.get_user_default("company"),
 				},
 				{
 					fieldtype: "Select",

--- a/india_banking/public/js/payment_order.js
+++ b/india_banking/public/js/payment_order.js
@@ -2,16 +2,11 @@ frappe.ui.form.on("Payment Order", {
 	onload(frm) {
 		// Set summary based on party or voucher
 		if (frm.doc.docstatus == 0) {
-			frappe.db
-				.get_single_value(
-					"India Banking Settings",
-					"summarise_payment_based_on"
-				)
-				.then((res) => {
-					if (!res.exc) {
-						frm.set_value("summarise_payment_based_on", res);
-					}
-				});
+			frappe.db.get_single_value("India Banking Settings", "summarise_payment_based_on").then((res) => {
+				if (!res.exc) {
+					frm.set_value("summarise_payment_based_on", res);
+				}
+			});
 		}
 
 		// Clear the references table for new documents
@@ -69,11 +64,7 @@ frappe.ui.form.on("Payment Order", {
 		const has_pending_payment = frm.doc.summary?.filter(
 			(item) => item.payment_status == "Pending"
 		).length;
-		if (
-			has_pending_payment &&
-			has_pending_payment < frm.doc.summary.length &&
-			frm.doc.docstatus == 1
-		){
+		if (has_pending_payment && has_pending_payment < frm.doc.summary.length && frm.doc.docstatus == 1) {
 			frm.add_custom_button(__("Cancel Pending Payments"), function () {
 				show_update_status_dialog(frm);
 			});
@@ -151,7 +142,7 @@ frappe.ui.form.on("Payment Order", {
 				bank: frm.doc.bank,
 				name: ["not in", existing_payment_requests],
 				company: frm.doc.company,
-				transaction_date: ["<=", frappe.datetime.get_today()]
+				transaction_date: ["<=", frappe.datetime.get_today()],
 			},
 		});
 	},
@@ -216,11 +207,7 @@ frappe.ui.form.on("Payment Order", {
 			get_query: function () {
 				// Extract unique reference names from the references table
 				const existing_journal_entries = [
-					...new Set(
-						(frm.doc.references || []).map(
-							(reference) => reference.reference_name
-						)
-					),
+					...new Set((frm.doc.references || []).map((reference) => reference.reference_name)),
 				];
 				return {
 					query: "india_banking.overrides.journal_entry.get_bank_entry",
@@ -235,14 +222,9 @@ frappe.ui.form.on("Payment Order", {
 
 	set_payment_and_status_buttons(frm) {
 		// Check if the document is in a pending state and user has write permissions
-		if (
-			frm.doc.docstatus === 1 &&
-			frm.has_perm("write")
-		) {
+		if (frm.doc.docstatus === 1 && frm.has_perm("write")) {
 			// Check if any summary item has a payment status of "Pending"
-			const has_pending_payments = frm.doc.summary.some(
-				(item) => item.payment_status === "Pending"
-			);
+			const has_pending_payments = frm.doc.summary.some((item) => item.payment_status === "Pending");
 
 			if (frappe.user_roles.includes("Payment Manager") && has_pending_payments) {
 				// Add a custom button to initiate payment
@@ -252,25 +234,20 @@ frappe.ui.form.on("Payment Order", {
 			}
 		}
 
-		if (
-			frm.doc.docstatus === 1 &&
-			frm.has_perm("write")
-		) {
+		if (frm.doc.docstatus === 1 && frm.has_perm("write")) {
 			const has_initiated_or_non_pending = frm.doc.summary.some(
-				(item) =>
-					item.payment_status === "Initiated" ||
-					item.payment_status !== "Pending"
+				(item) => item.payment_status === "Initiated" || item.payment_status !== "Pending"
 			);
 
 			if (has_initiated_or_non_pending) {
 				frm.dashboard.add_comment(
 					"Payment is already initiated. Check the status using the 'Get Status' button before trying again.",
-					permanent = false
+					"blue",
+					false
 				);
 				frm.add_custom_button(__("Get Status"), () => {
 					frappe.call({
-						method:
-							"india_banking.india_banking.doctype.bank_connector.bank_connector.get_payment_status",
+						method: "india_banking.india_banking.doctype.bank_connector.bank_connector.get_payment_status",
 						freeze: true,
 						freeze_message: __("Fetching payment status..."),
 						args: {
@@ -287,8 +264,7 @@ frappe.ui.form.on("Payment Order", {
 
 	make_payment: function (frm) {
 		frappe.call({
-			method:
-				"india_banking.india_banking.doctype.bank_connector.bank_connector.make_payment",
+			method: "india_banking.india_banking.doctype.bank_connector.bank_connector.make_payment",
 			freeze: true,
 			freeze_message: __("Initiating Payment..."),
 			args: {
@@ -328,8 +304,7 @@ frappe.ui.form.on("Payment Order", {
 				}
 
 				frappe.call({
-					method:
-						"india_banking.india_banking.doctype.bank_connector.bank_connector.make_payment",
+					method: "india_banking.india_banking.doctype.bank_connector.bank_connector.make_payment",
 					freeze: true,
 					freeze_message: __("Verifying OTP and processing payment..."),
 					args: {
@@ -493,10 +468,10 @@ const show_update_status_dialog = function (frm) {
 		],
 		primary_action: () => {
 			frm.call({
-				method:
-					"india_banking.india_banking.doc_events.payment_order.cancel_pending_payments",
+				method: "india_banking.india_banking.doc_events.payment_order.cancel_pending_payments",
 				args: {
 					data: dialog.get_values()["summary"],
+					payment_order_type: frm.doc.payment_order_type,
 				},
 				freeze: true,
 				freeze_message: __("Cancelling..."),

--- a/india_banking/public/js/payment_request_list.js
+++ b/india_banking/public/js/payment_request_list.js
@@ -1,12 +1,13 @@
-frappe.listview_settings["Payment Request"] = {
-	onload: function (listview) {
-		listview.page.add_inner_button(__("Make Adhoc Payment Request"), function () {
-			frappe.new_doc("Payment Request", {
-				payment_request_type: "Outward",
-				transaction_date: frappe.datetime.get_today(),
-				mode_of_payment: "Wire Transfer",
-				is_adhoc: 1,
-			});
+/* global INDICATORS */
+INDICATORS["Payment Ordered"] = "blue";
+
+frappe.listview_settings["Payment Request"].onload = function (listview) {
+	listview.page.add_inner_button(__("Make Adhoc Payment Request"), function () {
+		frappe.new_doc("Payment Request", {
+			payment_request_type: "Outward",
+			transaction_date: frappe.datetime.get_today(),
+			mode_of_payment: "Wire Transfer",
+			is_adhoc: 1,
 		});
-	},
+	});
 };


### PR DESCRIPTION
**Changes**

- Update pull Payment Entry filter
Improves the filter logic to ensure only the correct Payment Entries are fetched.

- Include Ordered status in Payment Request
Ensures Payment Requests with Ordered status are properly considered in the flow.

- Fix unlinking of Payment Entry from Payment Order
Corrects the unlink behavior to avoid inconsistent references and ensure clean detachment.

**backport to version-15**