### PR TITLE
fix: post delay

### DIFF
--- a/india_banking/india_banking/doctype/bank_connector/bank_connector.json
+++ b/india_banking/india_banking/doctype/bank_connector/bank_connector.json
@@ -21,7 +21,8 @@
   "enqueue_payments_threshold",
   "column_break_rnqz",
   "enable_payment_delay",
-  "payment_call_interval"
+  "payment_call_interval",
+  "is_post_delay"
  ],
  "fields": [
   {
@@ -118,11 +119,19 @@
    "fieldname": "enqueue_payments_threshold",
    "fieldtype": "Int",
    "label": "Enqueue Payments Threshold"
+  },
+  {
+   "default": "0",
+   "depends_on": "enable_payment_delay",
+   "description": "If enabled, consecutive requests wait Payment Call Interval (N seconds) after the previous one completes.",
+   "fieldname": "is_post_delay",
+   "fieldtype": "Check",
+   "label": "Is Post delay"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-07 11:26:52.813118",
+ "modified": "2026-02-26 13:31:33.665293",
  "modified_by": "Administrator",
  "module": "India Banking",
  "name": "Bank Connector",

--- a/india_banking/india_banking/doctype/bank_connector/bank_connector.py
+++ b/india_banking/india_banking/doctype/bank_connector/bank_connector.py
@@ -428,13 +428,18 @@ class BankConnector(Document):
 			return None
 
 		payment_delay = 0
-		if not last_call:
-			last_call = time.time()
+
+		# Add a N-second delay between consecutive payment call if enabled
+		if self.is_post_delay:
+			payment_delay = payment_call_interval
 		else:
-			last_duration_in_seconds = math.ceil(time.time() - last_call)
-			payment_delay = payment_call_interval - last_duration_in_seconds
-			if payment_delay < 0:
-				payment_delay = 0
+			if not last_call:
+				last_call = time.time()
+			else:
+				last_duration_in_seconds = math.ceil(time.time() - last_call)
+				payment_delay = payment_call_interval - last_duration_in_seconds
+				if payment_delay < 0:
+					payment_delay = 0
 
 		if payment_delay:
 			# Minimum 1-minute delay to avoid invalid behavior

--- a/india_banking/india_banking/doctype/bank_connector/bank_connector.py
+++ b/india_banking/india_banking/doctype/bank_connector/bank_connector.py
@@ -12,6 +12,9 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_days, cint, cstr, flt, getdate
 
+from india_banking.india_banking.doc_events.payment_order import (
+	unlink_payment_reference,
+)
 from india_banking.india_banking.doctype.india_banking_request_log.india_banking_request_log import (
 	create_api_log,
 )
@@ -172,8 +175,8 @@ class BankConnector(Document):
 							"file_sequence_number": file_sequence_number,
 						},
 					)
-
 				for _name, details in summary_details.items():
+					summary_ref = frappe._dict({"row_name": _name})
 					if details.get("payment_status", "") == "Accepted":
 						frappe.db.set_value(
 							"Payment Order Summary",
@@ -200,7 +203,14 @@ class BankConnector(Document):
 						summary = frappe.get_doc("Payment Order Summary", _name)
 						if summary.payment_entry:
 							self.process_bank_payment_requests(payment_order, summary)
-
+							if payment_order.payment_order_type == "Payment Request":
+								payment_entry_doc = frappe.get_doc(
+									"Payment Entry", summary.payment_entry
+								)
+								if payment_entry_doc.docstatus == 1:
+									payment_entry_doc.cancel()
+							else:
+								unlink_payment_reference(summary_ref)
 							payment_entry_doc = frappe.get_doc(
 								"Payment Entry", summary.payment_entry
 							)
@@ -264,10 +274,6 @@ class BankConnector(Document):
 			)
 
 	def verify_status_response(self, response, payment_order):
-		from india_banking.india_banking.doc_events.payment_order import (
-			unlink_payment_reference,
-		)
-
 		status_count_map = {
 			"Processed": 0,
 			"Pending": 0,


### PR DESCRIPTION
This PR adds support for an optional post-request delay when processing payment requests. When the is_post_delay setting is enabled, the system waits  N seconds after a request completes before sending the next one.


<img width="713" height="349" alt="image" src="https://github.com/user-attachments/assets/54b5bf4a-6a7f-41d8-8387-d79c17193fea" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Post Delay" configuration option to Bank Connector to enable applying delay intervals after payment calls based on the configured call interval.

* **Improvements**
  * Improved payment response verification to better handle cancellations for Payment Requests and to more reliably clear payment references for other order types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->