### PR TITLE
feat: add validation to restrict journal creation

### DIFF
--- a/india_banking/india_banking/doctype/india_banking_connector/india_banking_connector.json
+++ b/india_banking/india_banking/doctype/india_banking_connector/india_banking_connector.json
@@ -39,6 +39,7 @@
   "retry_period",
   "reposting_configurations_section",
   "auto_update_posting_date_as_payment_date",
+  "restrict_journal_entry_without_bank_account",
   "doctype_configuration_section",
   "doctype_naming_series",
   "payment_notifications_section",
@@ -207,6 +208,13 @@
    "fieldname": "auto_update_posting_date_as_payment_date",
    "fieldtype": "Check",
    "label": "Auto Update Posting Date as Payment Date"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, Journal Entry creation will be restricted if the party does not have a linked Bank Account.",
+   "fieldname": "restrict_journal_entry_without_bank_account",
+   "fieldtype": "Check",
+   "label": "Restrict Journal Entry Without Party Bank Account"
   },
   {
    "fieldname": "doctype_configuration_section",

--- a/india_banking/overrides/journal_entry.py
+++ b/india_banking/overrides/journal_entry.py
@@ -238,8 +238,12 @@ def update_party_bank(self, method):
 	parties_without_bank_account = []
 
 	for row in self.accounts:
-		if row.bank_account and frappe.db.get_value(
-			"Bank Account", row.bank_account, "is_company_account"
+		if (
+			row.bank_account
+			and not restrict_without_bank_account
+			and frappe.db.get_value(
+				"Bank Account", row.bank_account, "is_company_account"
+			)
 		):
 			restrict_without_bank_account = frappe.db.get_value(
 				"India Banking Connector",

--- a/india_banking/overrides/journal_entry.py
+++ b/india_banking/overrides/journal_entry.py
@@ -234,7 +234,20 @@ def update_party_bank(self, method):
 	if self.voucher_type != "Bank Entry":
 		return
 
+	restrict_without_bank_account = False
+	parties_without_bank_account = []
+
 	for row in self.accounts:
+		if row.bank_account and frappe.db.get_value(
+			"Bank Account", row.bank_account, "is_company_account"
+		):
+			restrict_without_bank_account = frappe.db.get_value(
+				"India Banking Connector",
+				{"bank_account": row.bank_account},
+				"restrict_journal_entry_without_bank_account",
+			)
+			continue
+
 		if row.party_type and row.party and not row.bank_account:
 			account_type = frappe.get_cached_value(
 				"Account", row.account, "account_type"
@@ -248,3 +261,21 @@ def update_party_bank(self, method):
 				)
 				if bank_account:
 					row.bank_account = bank_account
+				else:
+					parties_without_bank_account.append(
+						_("Row #{0}: {1} - {2}").format(
+							row.idx, row.party_type, row.party
+						)
+					)
+
+	print(restrict_without_bank_account, parties_without_bank_account)
+	if restrict_without_bank_account and parties_without_bank_account:
+		frappe.throw(
+			_(
+				"The following parties do not have a Bank Account."
+				" Please add a Bank Account before creating this Journal Entry."
+			)
+			+ "<br><br>"
+			+ "<br>".join(parties_without_bank_account),
+			title=_("Missing Party Bank Account"),
+		)

--- a/india_banking/overrides/journal_entry.py
+++ b/india_banking/overrides/journal_entry.py
@@ -268,7 +268,6 @@ def update_party_bank(self, method):
 						)
 					)
 
-	print(restrict_without_bank_account, parties_without_bank_account)
 	if restrict_without_bank_account and parties_without_bank_account:
 		frappe.throw(
 			_(


### PR DESCRIPTION
**Description:**
- Added a new checkbox "Restrict Journal Entry Without Party Bank Account" in the India Banking Connector settings (under the Settings > Reposting Configurations section)
- When enabled, Journal Entry (Bank Entry) creation is blocked if any party with a Payable or Receivable account type does not have a linked Bank Account
- All parties' missing bank accounts are collected and displayed in a single error message for easy resolution

<img width="1797" height="857" alt="image" src="https://github.com/user-attachments/assets/8d2f9e70-fd09-4237-a9f8-221cffe3d45a" />

<img width="1794" height="908" alt="image" src="https://github.com/user-attachments/assets/eaca14b0-8340-43de-a4f3-f073e93701b2" />
