### PR TITLE
feat: make payment after successfull bank transaction

### DIFF
--- a/india_banking/india_banking/doctype/india_banking_connector/india_banking_connector.json
+++ b/india_banking/india_banking/doctype/india_banking_connector/india_banking_connector.json
@@ -33,6 +33,7 @@
   "retry_interval_minutes",
   "batch_size",
   "last_execution",
+  "create_payment_after_success",
   "status_configuration_column",
   "auto_update_payment_status",
   "status_check_at",
@@ -274,6 +275,12 @@
    "fieldname": "auto_post_payments",
    "fieldtype": "Check",
    "label": "Auto Post Payments"
+  },
+  {
+   "description": "If checked: a Payment Entry will be created only after receiving a successful response from the connector.\n<br>If unchecked: a Payment Entry is created immediately upon submitting the payment order.",
+   "fieldname": "create_payment_after_success",
+   "fieldtype": "Check",
+   "label": "Create Payment After Successful Bank Transaction"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/india_banking/india_banking/doctype/payment_order_summary/payment_order_summary.json
+++ b/india_banking/india_banking/doctype/payment_order_summary/payment_order_summary.json
@@ -27,6 +27,7 @@
   "account",
   "tax_withholding_category",
   "payment_entry",
+  "create_payment_entry",
   "journal_entry_account",
   "reference_doctype",
   "reference_name",
@@ -132,6 +133,12 @@
    "fieldtype": "Data",
    "label": "Payment Entry",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval: parent.payment_order_type == \"Payment Request\" && doc.docstatus == 1;",
+   "fieldname": "create_payment_entry",
+   "fieldtype": "Button",
+   "label": "Create Payment Entry"
   },
   {
    "fieldname": "reference_doctype",

--- a/india_banking/overrides/payment_order.py
+++ b/india_banking/overrides/payment_order.py
@@ -160,7 +160,11 @@ class CustomPaymentOrder(PaymentOrder):
 			"Payment Entry",
 			"Journal Entry",
 		]:
-			if self.payment_order_type == "Payment Request":
+			if self.payment_order_type == "Payment Request" and not frappe.db.get_value(
+				"India Banking Connector",
+				{"bank_account": self.company_bank_account},
+				"create_payment_after_success",
+			):
 				make_payment_entries(self.name)
 
 			self.update_payment_status()

--- a/india_banking/public/js/payment_order.js
+++ b/india_banking/public/js/payment_order.js
@@ -500,6 +500,25 @@ frappe.ui.form.on("Payment Order", {
 	},
 });
 
+frappe.ui.form.on("Payment Order Summary", {
+	create_payment_entry(frm, cdt, cdn) {
+		if (frm.doc.docstatus != 1) return;
+		const row = locals[cdt][cdn];
+		frm.call({
+			method: "india_banking.india_banking.doc_events.payment_order.make_payment_entries",
+			freeze: true,
+			freeze_message: __("Creating Payment Entry..."),
+			args: {
+				docname: frm.doc.name,
+				summary_name: row.name,
+			},
+			callback: function (r) {
+				frm.reload_doc();
+			},
+		});
+	},
+});
+
 const show_update_status_dialog = function (frm) {
 	frm.data = [];
 	const dialog = new frappe.ui.Dialog({

--- a/india_banking/tasks.py
+++ b/india_banking/tasks.py
@@ -53,10 +53,14 @@ def job_at_midnight():
 
 
 def update_payment_status(check_processed_payments=False, connector=None):
-	if connector and not frappe.db.get_value(
-		"India Banking Connector", connector, "auto_update_payment_status"
-	):
-		return
+	if connector:
+		auto_update_payment_status, create_payment_after_success = frappe.db.get_value(
+			"India Banking Connector",
+			connector,
+			["auto_update_payment_status", "create_payment_after_success"],
+		)
+		if not auto_update_payment_status or create_payment_after_success:
+			return
 
 	PaymentOrder = DocType("Payment Order")
 	PaymentOrderSummary = DocType("Payment Order Summary")


### PR DESCRIPTION
**Description:**
Introduce functionality to automatically create a Payment Entry only after the corresponding bank transaction is successfully completed.