### PR TITLE
fix: payment request creation flag

### DIFF
--- a/india_banking/__init__.py
+++ b/india_banking/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "15.7.0"
+__version__ = "15.7.1"
 __title__ = "India Banking"

--- a/india_banking/install.py
+++ b/india_banking/install.py
@@ -16,7 +16,6 @@ from india_banking.default import (
 
 def after_install():
 	click.secho("* Updating India Banking Customisations")
-	toggle_payment_request_creation(True)
 	make_custom_fields()
 	create_property_setter()
 	toggle_reqd_for_reference_in_payment_order(False)
@@ -43,17 +42,6 @@ def update_allowed_payment_doctypes():
 		"India Banking Settings",
 		"allowed_payment_doctypes",
 		"\n".join(ALLOWED_PAYMENT_DOCTYPE),
-	)
-
-
-def toggle_payment_request_creation(allow=True):
-	click.secho(
-		" -> {} Payment Request Creation...".format(
-			"Enabling" if allow else "Disabling"
-		)
-	)
-	frappe.db.set_value(
-		"DocType", "Payment Request", {"in_create": not allow, "track_changes": allow}
 	)
 
 

--- a/india_banking/patches.txt
+++ b/india_banking/patches.txt
@@ -6,3 +6,4 @@ india_banking.patches.v15_0.remove_payroll_entry_custom_fields #31032025
 
 india_banking.patches.v15_0.update_default_bank # 20260320
 india_banking.patches.v15_0.update_custom_field # 20260320
+execute:frappe.db.set_value("DocType", "Payment Request", {"in_create": 1, "track_changes": 1})

--- a/india_banking/patches/v15_0/remove_payroll_entry_custom_fields.py
+++ b/india_banking/patches/v15_0/remove_payroll_entry_custom_fields.py
@@ -1,7 +1,7 @@
 import click
 import frappe
 
-from india_banking.install import make_custom_fields, toggle_payment_request_creation
+from india_banking.install import make_custom_fields
 
 
 def execute():
@@ -17,5 +17,4 @@ def execute():
 
 		frappe.clear_cache(doctype=doctype)
 
-	toggle_payment_request_creation()
 	make_custom_fields()

--- a/india_banking/patches/v1_0/update_custom_fields.py
+++ b/india_banking/patches/v1_0/update_custom_fields.py
@@ -1,10 +1,7 @@
-import frappe
-
-from india_banking.install import make_custom_fields, toggle_payment_request_creation
+from india_banking.install import make_custom_fields
 from india_banking.uninstall import delete_custom_fields
 
 
 def execute():
-	toggle_payment_request_creation()
 	delete_custom_fields()
 	make_custom_fields()

--- a/india_banking/uninstall.py
+++ b/india_banking/uninstall.py
@@ -5,14 +5,12 @@ from frappe.custom.doctype.property_setter.property_setter import delete_propert
 from india_banking.default import DEFAULT_WORKFLOW_LIST
 from india_banking.install import (
 	properties,
-	toggle_payment_request_creation,
 	toggle_reqd_for_reference_in_payment_order,
 )
 
 
 def before_uninstall():
 	delete_custom_fields()
-	toggle_payment_request_creation(False)
 	delete_propert_setters()
 	toggle_reqd_for_reference_in_payment_order(True)
 	delete_default_workflow()


### PR DESCRIPTION
## Summary

Payment Request creation from Purchase Invoice depends on the `Payment Request` DocType `in_create` flag. ERPNext checks this flag while deciding whether to show the **Create > Payment Request** button.

This change removes the India Banking toggle that was changing the `Payment Request.in_create` value, and adds a patch to keep `Payment Request.in_create` enabled.

## Changes

- Removed India Banking install-time toggle for Payment Request creation.
- Added a patch to set `Payment Request.in_create = 1`.
- This ensures the Payment Request button remains visible where ERPNext expects it.

## Reason

The Payment Request button visibility is decided based on the `in_create` option. If this flag is disabled, the button is hidden even when the Purchase Invoice is submitted and has outstanding amount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GST payables hold checkbox on Supplier doctype.
  * Payment Order now enforces read-only behavior for key financial fields.

* **Chores**
  * Simplified installation process for configuration setup.
  * Updated Bank Account field dependencies for better data integrity.
  * Applied data consistency updates to Payment Request records.
  * Version bumped to 15.7.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->