### PR TITLE
feat: add allowed roles to unlink Bank Payment Request from invoice

### DIFF
--- a/india_banking/hooks.py
+++ b/india_banking/hooks.py
@@ -156,7 +156,10 @@ override_doctype_class = {
 
 doc_events = {
 	"Bank Account": {
-		"validate": "india_banking.india_banking.doc_events.bank_account.validate_ifsc_code",
+		"validate": [
+			"india_banking.india_banking.doc_events.bank_account.validate_ifsc_code",
+			"india_banking.india_banking.doc_events.bank_account.validate_duplicate_receivers",
+		],
 	},
 	"Unreconcile Payment": {
 		"on_submit": "india_banking.india_banking.doc_events.unreconcile_payment.on_submit",

--- a/india_banking/india_banking/doc_events/bank_account.py
+++ b/india_banking/india_banking/doc_events/bank_account.py
@@ -8,17 +8,22 @@ def validate_ifsc_code(self, method):
 
 
 def validate_duplicate_receivers(self, method):
-	first_row_idx = {}
 	for row in (self.get("beneficiaries") or []):
 		if not row.company or not row.receiver_id:
 			continue
-		key = (row.company, row.receiver_id)
-		if key in first_row_idx:
-			receiver = row.beneficiary_name or row.beneficiary or row.receiver_id
+
+		if frappe.db.exists(
+			"Beneficiaries",
+			{
+				"company": row.company,
+				"receiver_id": row.receiver_id,
+				"parent": self.name,
+				"name": ["!=", row.name],
+			},
+		):
 			frappe.throw(
-				_("Row #{0}: Receiver {1} is already added for Company {2} (row #{3}).").format(
-					row.idx, frappe.bold(receiver), frappe.bold(row.company), first_row_idx[key]
+				_("Row #{0}: Receiver {1} is already added for Company {2}.").format(
+					row.idx, frappe.bold(row.receiver_id), frappe.bold(row.company)
 				),
 				title=_("Duplicate Receiver"),
 			)
-		first_row_idx[key] = row.idx

--- a/india_banking/india_banking/doc_events/bank_account.py
+++ b/india_banking/india_banking/doc_events/bank_account.py
@@ -5,3 +5,20 @@ def validate_ifsc_code(self, method):
 	pattern = re.compile("^[A-Z]{4}0[A-Z0-9]{6}$")
 	if not pattern.match(cstr(self.branch_code)):
 		frappe.throw(_("IFSC/Branch Code is not valid"))
+
+
+def validate_duplicate_receivers(self, method):
+	first_row_idx = {}
+	for row in (self.get("beneficiaries") or []):
+		if not row.company or not row.receiver_id:
+			continue
+		key = (row.company, row.receiver_id)
+		if key in first_row_idx:
+			receiver = row.beneficiary_name or row.beneficiary or row.receiver_id
+			frappe.throw(
+				_("Row #{0}: Receiver {1} is already added for Company {2} (row #{3}).").format(
+					row.idx, frappe.bold(receiver), frappe.bold(row.company), first_row_idx[key]
+				),
+				title=_("Duplicate Receiver"),
+			)
+		first_row_idx[key] = row.idx

--- a/india_banking/india_banking/doc_events/unreconcile_payment.py
+++ b/india_banking/india_banking/doc_events/unreconcile_payment.py
@@ -7,7 +7,7 @@ def on_submit(doc, method=None):
 
 	if frappe.db.get_value("Payment Entry", doc.voucher_no, "source_doctype") != "Bank Payment Request":
 		return
-	if not frappe.get_single("India Banking Settings").allow_unreconcile:
+	if not frappe.db.get_single_value("India Banking Settings", "allow_unreconcile"):
 		return
 
 	if not has_unlink_permission():
@@ -37,13 +37,23 @@ def on_submit(doc, method=None):
 			frappe.db.set_value("Bank Payment Request", reference.bank_payment_request, {"reference_doctype": "", "reference_name": ""})
 			frappe.db.set_value("Payment Order Reference", reference.name, {"reference_doctype": "", "reference_name": ""})
 
+UNLINK_ADMIN_ROLES = {"Administrator", "Local Admin"}
+
+
 def has_unlink_permission():
-	user_roles = frappe.get_roles()
-	if "Administrator" in user_roles:
+	user_roles = set(frappe.get_roles())
+	if UNLINK_ADMIN_ROLES & user_roles:
 		return True
 
-	allowed_roles = [d.role for d in frappe.get_single("India Banking Settings").unlink_allowed_roles]
-	return any(role in user_roles for role in allowed_roles)
+	allowed_roles = set(
+		frappe.get_all(
+			"Bank Payment Request Unlink Role",
+			filters={"parent": "India Banking Settings"},
+			pluck="role",
+		)
+	)
+	return bool(allowed_roles & user_roles)
+
 
 def get_payment_order_summary(payment_entry):
 	is_ammended = frappe.db.get_value("Payment Entry", payment_entry, "amended_from")

--- a/india_banking/india_banking/doc_events/unreconcile_payment.py
+++ b/india_banking/india_banking/doc_events/unreconcile_payment.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 
 def on_submit(doc, method=None):
 	if not doc.voucher_type == "Payment Entry":
@@ -8,6 +9,9 @@ def on_submit(doc, method=None):
 		return
 	if not frappe.get_single("India Banking Settings").allow_unreconcile:
 		return
+
+	if not has_unlink_permission():
+		frappe.throw(_("You are not permitted to unlink Bank Payment Request from the invoice."), frappe.PermissionError)
 
 	payment_order_summary = get_payment_order_summary(doc.voucher_no)
 
@@ -32,6 +36,14 @@ def on_submit(doc, method=None):
 		if values_match:
 			frappe.db.set_value("Bank Payment Request", reference.bank_payment_request, {"reference_doctype": "", "reference_name": ""})
 			frappe.db.set_value("Payment Order Reference", reference.name, {"reference_doctype": "", "reference_name": ""})
+
+def has_unlink_permission():
+	user_roles = frappe.get_roles()
+	if "Administrator" in user_roles:
+		return True
+
+	allowed_roles = [d.role for d in frappe.get_single("India Banking Settings").unlink_allowed_roles]
+	return any(role in user_roles for role in allowed_roles)
 
 def get_payment_order_summary(payment_entry):
 	is_ammended = frappe.db.get_value("Payment Entry", payment_entry, "amended_from")

--- a/india_banking/india_banking/doctype/bank_payment_request_unlink_role/bank_payment_request_unlink_role.json
+++ b/india_banking/india_banking/doctype/bank_payment_request_unlink_role/bank_payment_request_unlink_role.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-07-10 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "role"
+ ],
+ "fields": [
+  {
+   "fieldname": "role",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Role",
+   "options": "Role",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-07-10 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "India Banking",
+ "name": "Bank Payment Request Unlink Role",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/india_banking/india_banking/doctype/bank_payment_request_unlink_role/bank_payment_request_unlink_role.py
+++ b/india_banking/india_banking/doctype/bank_payment_request_unlink_role/bank_payment_request_unlink_role.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Aerele Technologies Private Limited and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BankPaymentRequestUnlinkRole(Document):
+	pass

--- a/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.js
+++ b/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.js
@@ -16,5 +16,10 @@ frappe.ui.form.on("India Banking Settings", {
         query: "india_banking.utils.get_allowed_doctypes",
       };
     });
+    frm.set_df_property(
+      "unlink_allowed_roles",
+      "read_only",
+      !frappe.user.has_role("Administrator")
+    );
   },
 });

--- a/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.js
+++ b/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.js
@@ -19,7 +19,10 @@ frappe.ui.form.on("India Banking Settings", {
     frm.set_df_property(
       "unlink_allowed_roles",
       "read_only",
-      !frappe.user.has_role("Administrator")
+      !(
+        frappe.user.has_role("Administrator") ||
+        frappe.user.has_role("Local Admin")
+      )
     );
   },
 });

--- a/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.json
+++ b/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.json
@@ -10,8 +10,10 @@
   "column_break_wjye",
   "default_email_format",
   "notify_party",
-  "allow_unreconcile",
   "enable_bank_account_workflow",
+  "unreconcile_settings_section",
+  "allow_unreconcile",
+  "unlink_allowed_roles",
   "bulk_creation_configurations_section",
   "submit_bank_payment_request",
   "column_break_xfzu",
@@ -81,10 +83,22 @@
    "label": "Retry Period(In Days) [eg:1=1 Day(s)]"
   },
   {
+   "fieldname": "unreconcile_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Unreconcile Settings"
+  },
+  {
    "default": "0",
    "fieldname": "allow_unreconcile",
    "fieldtype": "Check",
    "label": "Allow Unreconcile"
+  },
+  {
+   "description": "Roles allowed to unlink a Bank Payment Request from its invoice on unreconcile.",
+   "fieldname": "unlink_allowed_roles",
+   "fieldtype": "Table MultiSelect",
+   "label": "Allowed Roles to Unlink",
+   "options": "Bank Payment Request Unlink Role"
   },
   {
    "default": "0",

--- a/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.py
+++ b/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.py
@@ -1,9 +1,22 @@
 # Copyright (c) 2024, Aerele Technologies Private Limited and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class IndiaBankingSettings(Document):
-	pass
+	def validate(self):
+		self.validate_unlink_roles_change()
+
+	def validate_unlink_roles_change(self):
+		if "Administrator" in frappe.get_roles():
+			return
+
+		before = self.get_doc_before_save()
+		old_roles = sorted([d.role for d in before.unlink_allowed_roles]) if before else []
+		new_roles = sorted([d.role for d in self.unlink_allowed_roles])
+
+		if old_roles != new_roles:
+			frappe.throw(_("Only the Administrator can modify 'Allowed Roles to Unlink'."))

--- a/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.py
+++ b/india_banking/india_banking/doctype/india_banking_settings/india_banking_settings.py
@@ -11,7 +11,7 @@ class IndiaBankingSettings(Document):
 		self.validate_unlink_roles_change()
 
 	def validate_unlink_roles_change(self):
-		if "Administrator" in frappe.get_roles():
+		if {"Administrator", "Local Admin"} & set(frappe.get_roles()):
 			return
 
 		before = self.get_doc_before_save()
@@ -19,4 +19,6 @@ class IndiaBankingSettings(Document):
 		new_roles = sorted([d.role for d in self.unlink_allowed_roles])
 
 		if old_roles != new_roles:
-			frappe.throw(_("Only the Administrator can modify 'Allowed Roles to Unlink'."))
+			frappe.throw(
+				_("Only Administrator or Local Admin can modify 'Allowed Roles to Unlink'.")
+			)


### PR DESCRIPTION
1. Added a setting to configure the roles allowed to unlink Bank Payment Requests from invoices.
2. Restricted the unlink action to only users with the configured roles while preserving the existing workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent duplicate beneficiary receivers for the same company within a bank account.
  * Added configurable roles allowed to unlink bank payment requests during unreconciliation.
  * Added a dedicated role configuration table in India Banking Settings.

* **Bug Fixes**
  * Unauthorized users can no longer unlink related bank payment requests.
  * Non-Administrators cannot modify the configured unlink permissions.
  * Clear, localized errors now identify duplicate receiver entries and permission issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->