### PR TITLE
feat: add LEI number to Payment Order Summary

### DIFF
--- a/india_banking/india_banking/doctype/india_banking_connector/india_banking_connector.py
+++ b/india_banking/india_banking/doctype/india_banking_connector/india_banking_connector.py
@@ -550,6 +550,7 @@ class IndiaBankingConnector(Document):
 			summary.party_type, summary.party, get_party_field_name(summary.party_type)
 		)
 		payload.address = json.dumps(get_bank_address_details(summary.bank_account))
+		payload.lei = summary.get("lei_number") or ""
 
 		response = request.post(
 			url, headers=headers, data=json.dumps(payload), timeout=100

--- a/india_banking/india_banking/doctype/payment_order_summary/payment_order_summary.json
+++ b/india_banking/india_banking/doctype/payment_order_summary/payment_order_summary.json
@@ -57,6 +57,14 @@
    "reqd": 1
   },
   {
+   "fieldname": "lei_number",
+   "fieldtype": "Data",
+   "label": "LEI Number",
+   "read_only": 1,
+   "print_hide": 1,
+   "depends_on": "eval:doc.lei_number"
+  },
+  {
    "columns": 2,
    "fieldname": "amount",
    "fieldtype": "Currency",

--- a/india_banking/overrides/payment_order.py
+++ b/india_banking/overrides/payment_order.py
@@ -100,6 +100,9 @@ class CustomPaymentOrder(PaymentOrder):
 							f"LEI Number required for payment > 50 Cr. For {payment.party_type} - {payment.party} - {payment.amount}"
 						)
 					)
+				payment.lei_number = lei_number or ""
+			else:
+				payment.lei_number = ""
 
 			if "A2A" in mode_of_transfer.mode and payment.bank != self.company_bank:
 				frappe.throw(


### PR DESCRIPTION
Adds LEI number support to Payment Order Summary so it can be transmitted to banks for NEFT/RTGS payments above ₹50 Cr.