### PR TITLE
fix: cancel failed payment entries linked to payment orders

### DIFF
--- a/india_banking/india_banking/doc_events/payment_entry.py
+++ b/india_banking/india_banking/doc_events/payment_entry.py
@@ -1,9 +1,8 @@
-from india_banking.utils import get_payment_order_summary, unlink_bank_payment
-
-
 def on_cancel(doc, method=None):
-	return
-	if doc.source_doctype == "Payment Request":
-		payment_order_summary = get_payment_order_summary(doc.name)
+	if not doc.flags.from_bank_failure:
+		return
 
-		unlink_bank_payment(payment_order_summary)
+	ignored_doctypes = list(doc.get("ignore_linked_doctypes") or [])
+	if "Payment Order" not in ignored_doctypes:
+		ignored_doctypes.append("Payment Order")
+	doc.ignore_linked_doctypes = ignored_doctypes

--- a/india_banking/india_banking/doctype/india_banking_connector/india_banking_connector.py
+++ b/india_banking/india_banking/doctype/india_banking_connector/india_banking_connector.py
@@ -465,13 +465,7 @@ class IndiaBankingConnector(Document):
 
 			payment_entry_doc = frappe.get_doc("Payment Entry", summary.payment_entry)
 			if payment_entry_doc.docstatus == 1:
-				ignored_doctypes = list(
-					payment_entry_doc.get("ignore_linked_doctypes") or []
-				)
-				if "Payment Order" not in ignored_doctypes:
-					ignored_doctypes.append("Payment Order")
-				payment_entry_doc.ignore_linked_doctypes = ignored_doctypes
-
+				payment_entry_doc.flags.from_bank_failure = True
 				try:
 					payment_entry_doc.cancel()
 				except Exception:
@@ -488,6 +482,8 @@ class IndiaBankingConnector(Document):
 						),
 					)
 
+				finally:
+					payment_entry_doc.flags.pop("from_bank_failure", None)
 		if summary.journal_entry_account:
 			frappe.db.set_value(
 				"Journal Entry Account",

--- a/india_banking/india_banking/doctype/india_banking_connector/india_banking_connector.py
+++ b/india_banking/india_banking/doctype/india_banking_connector/india_banking_connector.py
@@ -319,22 +319,7 @@ class IndiaBankingConnector(Document):
 							},
 						)
 						summary = frappe.get_doc("Payment Order Summary", _name)
-						if summary.payment_entry:
-							self.process_bank_payment_requests(payment_order, summary)
-
-							payment_entry_doc = frappe.get_doc(
-								"Payment Entry", summary.payment_entry
-							)
-							if payment_entry_doc.docstatus == 1:
-								payment_entry_doc.cancel()
-
-						if summary.journal_entry_account:
-							frappe.db.set_value(
-								"Journal Entry Account",
-								summary.journal_entry_account,
-								"payment_status",
-								"Failed",
-							)
+						self.handle_failed_summary(payment_order, summary)
 						self.failed_count += 1
 
 					elif details.get("payment_status", "") == "Request Failure":
@@ -444,22 +429,7 @@ class IndiaBankingConnector(Document):
 							},
 						)
 
-						if summary.payment_entry:
-							self.process_bank_payment_requests(payment_order, summary)
-
-							payment_entry_doc = frappe.get_doc(
-								"Payment Entry", summary.payment_entry
-							)
-							if payment_entry_doc.docstatus == 1:
-								payment_entry_doc.cancel()
-
-						if summary.journal_entry_account:
-							frappe.db.set_value(
-								"Journal Entry Account",
-								summary.journal_entry_account,
-								"payment_status",
-								"Failed",
-							)
+						self.handle_failed_summary(payment_order, summary)
 						self.status_count_map["Failed"] += 1
 
 					elif status_details.status == "Rejected":
@@ -473,22 +443,7 @@ class IndiaBankingConnector(Document):
 							},
 						)
 
-						if summary.payment_entry:
-							self.process_bank_payment_requests(payment_order, summary)
-
-							payment_entry_doc = frappe.get_doc(
-								"Payment Entry", summary.payment_entry
-							)
-							if payment_entry_doc.docstatus == 1:
-								payment_entry_doc.cancel()
-
-						if summary.journal_entry_account:
-							frappe.db.set_value(
-								"Journal Entry Account",
-								summary.journal_entry_account,
-								"payment_status",
-								"Failed",
-							)
+						self.handle_failed_summary(payment_order, summary)
 						self.status_count_map["Rejected"] += 1
 
 			elif payment_status == "FAILED":
@@ -503,6 +458,43 @@ class IndiaBankingConnector(Document):
 
 		else:
 			frappe.throw("Invalid Request")
+
+	def handle_failed_summary(self, payment_order, summary):
+		if summary.payment_entry:
+			self.process_bank_payment_requests(payment_order, summary)
+
+			payment_entry_doc = frappe.get_doc("Payment Entry", summary.payment_entry)
+			if payment_entry_doc.docstatus == 1:
+				ignored_doctypes = list(
+					payment_entry_doc.get("ignore_linked_doctypes") or []
+				)
+				if "Payment Order" not in ignored_doctypes:
+					ignored_doctypes.append("Payment Order")
+				payment_entry_doc.ignore_linked_doctypes = ignored_doctypes
+
+				try:
+					payment_entry_doc.cancel()
+				except Exception:
+					frappe.log_error(
+						title="Failed Payment Entry Cancellation",
+						message=(
+							"Could not cancel Payment Entry {0} for Payment Order {1}, "
+							"summary {2}.\n\n{3}"
+						).format(
+							payment_entry_doc.name,
+							payment_order.name,
+							summary.name,
+							frappe.get_traceback(),
+						),
+					)
+
+		if summary.journal_entry_account:
+			frappe.db.set_value(
+				"Journal Entry Account",
+				summary.journal_entry_account,
+				"payment_status",
+				"Failed",
+			)
 
 	def show_status_count(self, status_count_map):
 		msg = ""

--- a/india_banking/india_banking/doctype/india_banking_connector/test_india_banking_connector.py
+++ b/india_banking/india_banking/doctype/india_banking_connector/test_india_banking_connector.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 from unittest import TestCase
-from unittest.mock import PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import frappe
 
@@ -101,6 +101,67 @@ class TestIndiaBankingConnector(TestCase):
 			"status",
 			"Partially Approved",
 		)
+
+	def test_status_response_handles_mixed_processed_and_failed_summaries(self):
+		connector = self.get_connector()
+		payment_order = self.get_payment_order(
+			[
+				{"name": "processed-row", "payment_entry": None},
+				{"name": "failed-row", "payment_entry": "PE-FAILED"},
+			]
+		)
+		response = frappe._dict({"ok": True})
+		response_details = {
+			"payment_status": "PROCESSED",
+			"summary_details": {
+				"processed-row": {
+					"status": "Processed",
+					"utr_number": "UTR-001",
+					"message": "Payment completed",
+				},
+				"failed-row": {"status": "Failed", "message": "Insufficient funds"},
+			},
+		}
+
+		with (
+			patch.object(
+				connector, "get_response_details", return_value=response_details
+			),
+			patch.object(connector, "handle_failed_summary") as handle_failed_summary,
+			patch("frappe.db.set_value"),
+		):
+			connector.verify_status_response(response, payment_order)
+
+		handle_failed_summary.assert_called_once_with(
+			payment_order, payment_order.summary[1]
+		)
+		self.assertEqual(connector.status_count_map["Processed"], 1)
+		self.assertEqual(connector.status_count_map["Failed"], 1)
+
+	def test_failed_payment_entry_cancellation_ignores_payment_order_link_only(self):
+		payment_order = self.get_payment_order([])
+		connector = self.get_connector()
+		summary = frappe._dict(
+			{
+				"name": "summary-row",
+				"payment_entry": "PE-FAILED",
+				"journal_entry_account": None,
+			}
+		)
+		payment_entry = MagicMock(docstatus=1, name="PE-FAILED")
+		payment_entry.get.return_value = []
+
+		with (
+			patch.object(
+				connector, "process_bank_payment_requests"
+			) as process_requests,
+			patch("frappe.get_doc", return_value=payment_entry),
+		):
+			connector.handle_failed_summary(payment_order, summary)
+
+		process_requests.assert_called_once_with(payment_order, summary)
+		self.assertEqual(payment_entry.ignore_linked_doctypes, ["Payment Order"])
+		payment_entry.cancel.assert_called_once()
 
 	def test_get_bank_statement_uses_request_timeout(self):
 		connector = self.get_connector()

--- a/india_banking/india_banking/doctype/india_banking_connector/test_india_banking_connector.py
+++ b/india_banking/india_banking/doctype/india_banking_connector/test_india_banking_connector.py
@@ -6,6 +6,9 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import frappe
 
+from india_banking.india_banking.doc_events.payment_entry import (
+	on_cancel as on_payment_entry_cancel,
+)
 from india_banking.india_banking.doctype.india_banking_connector.india_banking_connector import (
 	IndiaBankingConnector,
 )
@@ -149,7 +152,20 @@ class TestIndiaBankingConnector(TestCase):
 			}
 		)
 		payment_entry = MagicMock(docstatus=1, name="PE-FAILED")
-		payment_entry.get.return_value = []
+		payment_entry.flags = frappe._dict()
+
+		def get_value(fieldname):
+			if fieldname == "ignore_linked_doctypes":
+				return getattr(payment_entry, "ignore_linked_doctypes", None)
+			return None
+
+		def cancel():
+			self.assertTrue(payment_entry.flags.from_bank_failure)
+			payment_entry.ignore_linked_doctypes = ["GL Entry"]
+			on_payment_entry_cancel(payment_entry)
+
+		payment_entry.get.side_effect = get_value
+		payment_entry.cancel.side_effect = cancel
 
 		with (
 			patch.object(
@@ -160,7 +176,10 @@ class TestIndiaBankingConnector(TestCase):
 			connector.handle_failed_summary(payment_order, summary)
 
 		process_requests.assert_called_once_with(payment_order, summary)
-		self.assertEqual(payment_entry.ignore_linked_doctypes, ["Payment Order"])
+		self.assertEqual(
+			payment_entry.ignore_linked_doctypes, ["GL Entry", "Payment Order"]
+		)
+		self.assertNotIn("from_bank_failure", payment_entry.flags)
 		payment_entry.cancel.assert_called_once()
 
 	def test_get_bank_statement_uses_request_timeout(self):


### PR DESCRIPTION
Fixes Payment Entry cancellation for failed or rejected bank payments while preserving Payment Order references and audit history.